### PR TITLE
Let `Microsoft.VisualStudio.SlnGen` dependency development only

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SlnGen" Version="11.1.0" />
+    <PackageReference Include="Microsoft.VisualStudio.SlnGen" Version="11.1.0" PrivateAssets="all" />
   </ItemGroup>  
 </Project>


### PR DESCRIPTION
Configure `Microsoft.VisualStudio.SlnGen` `PrivateAssets`

https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets